### PR TITLE
Renamed classes with a new prefix 'AL'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 - Modify the API usage so that it returns first class Objects instead of just a list
 
+## [0.3.0]
+### Changed
+- Class renames (which will change the API).  Now all classes are prefixed with `AL` (Apex Legends)
+
 ## [0.2.1]
 ### Changed
 - the module is now exporting all the classes through the `__init__.py` which will make importing

--- a/README.md
+++ b/README.md
@@ -17,13 +17,13 @@ You can install it from source, or pip (recommended)
 
 ```python
 from apex_legends_api import ApexLegendsAPI
-from apex_legends_api import Platform, Action
+from apex_legends_api import ALPlatform, ALAction
 
 api = ApexLegendsAPI(api_key='<api_key>')
 
 player = '<PlayerName>'
-platform = Platform.PC
-action = Action.GET
+platform = ALPlatform.PC
+action = ALAction.GET
 
 basic = api.basic_player_stats(player_name=player, platform=platform)
 history = api.match_history(player_name=player, platform=platform, action=action)

--- a/apex_legends_api/ApexLegendsAPI.py
+++ b/apex_legends_api/ApexLegendsAPI.py
@@ -8,7 +8,7 @@ https://apexlegendsapi.com
 
 import json
 import requests
-from base import Platform, Action
+from base import ALPlatform, ALAction
 
 
 class ApexLegendsAPI:
@@ -38,7 +38,7 @@ class ApexLegendsAPI:
             response_text = [response_text]
         return response_text
 
-    def basic_player_stats(self, player_name: str, platform: Platform) -> list:
+    def basic_player_stats(self, player_name: str, platform: ALPlatform) -> list:
         """
         Query the server for the given player / platform and returns a dictionary of their
         stats.
@@ -51,7 +51,7 @@ class ApexLegendsAPI:
         endpoint = f"&platform={platform.value}&player={player_name}"
         return self.make_request(endpoint)
 
-    def match_history(self, player_name: str, platform: Platform, action: Action) -> list:
+    def match_history(self, player_name: str, platform: ALPlatform, action: ALAction) -> list:
         """
         Query the server for the given player / platform and return a dictionary of their
         match history

--- a/apex_legends_api/__init__.py
+++ b/apex_legends_api/__init__.py
@@ -1,8 +1,8 @@
 from .ApexLegendsAPI import ApexLegendsAPI
-from .base import Platform, Action
+from .base import ALPlatform, ALAction
 
 __all__ = [
     'ApexLegendsAPI',
-    'Platform',
-    'Action'
+    'ALPlatform',
+    'ALAction'
 ]

--- a/apex_legends_api/base.py
+++ b/apex_legends_api/base.py
@@ -5,14 +5,14 @@ contains some of the base / utility classes and Enums
 from enum import Enum
 
 
-class Platform(Enum):
+class ALPlatform(Enum):
     """ Three platforms available """
     XBOX = "X1"
     PSN = "PS4"
     PC = "PC"
 
 
-class Action(Enum):
+class ALAction(Enum):
     """ Three actions available """
     INFO = "info"  # return the players you're currently tracking
     GET = "get"  # return ALL tracked events for the player

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open('requirements.txt') as f:
 
 setup(
     name='apex-legends-api',
-    version='0.2.1',
+    version='0.3.0',
     packages=['apex_legends_api'],
     python_requires='>=3.6.*',
     url='https://github.com/johnsturgeon/apex-legends-api',


### PR DESCRIPTION
This resolves #13

- It was done to prevent possible naming collisions since classes with names like `Player` and `Action` might be relatively common